### PR TITLE
Fix:  Garbled 2bite character

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -206,7 +206,7 @@ class MWS(object):
             # be aware that response.content returns the content in bytes while response.text calls
             # response.content and converts it to unicode.
 
-            data = response.content
+            data = response.content.decode('utf-8')
             # I do not check the headers to decide which content structure to server simply because sometimes
             # Amazon's MWS API returns XML error responses with "text/plain" as the Content-Type.
             rootkey = kwargs.get('rootkey', extra_data.get("Action") + "Result")


### PR DESCRIPTION
When I get 2 bite character from API def parsed got Garbled character.
So I add decode('utf-8') in def make_request.